### PR TITLE
Add configuration for poem

### DIFF
--- a/.github/workflows/redrover_review.yml
+++ b/.github/workflows/redrover_review.yml
@@ -37,3 +37,5 @@ jobs:
             !dist/**
             !**/*.lock
           system_message: ${{ steps.file.outputs.content }}
+          poem_enabled: true
+          less_verbose_review: false

--- a/action.yml
+++ b/action.yml
@@ -219,7 +219,6 @@ inputs:
 
       Avoid additional commentary as this summary will be added as a comment on the 
       GitHub pull request. Use the titles "Walkthrough" and "Changes" and they must be H2.
-
   summarize_release_notes:
     required: false
     description:
@@ -231,6 +230,19 @@ inputs:
       "Documentation", "Refactor", "Style", "Test", "Chore", or "Revert". Provide a bullet-point list, 
       e.g., "- New Feature: Added search functionality to the UI". Limit your response to 50-100 words 
       and emphasize features visible to the end-user while omitting code-level details.
+  poem_enabled:
+    required: false
+    description: 'Enable the poem generation at the bottom of the full summary'
+    default: 'false'
+  poem:
+    required: false
+    description:
+      'The prompt for generating the poem, only used if poem_enabled is true'
+    default: |
+      **Poem**: Below the changes, include a whimsical, short poem written by 
+      a dog to celebrate the changes. Format the poem as a quote using 
+      the ">" symbol and feel free to use emojis where relevant. Do not add
+      extra lines breaks or <br> tags at the end of each poem line.
   language:
     required: false
     description: ISO code for the response language

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,9 @@ async function run(): Promise<void> {
 
   const prompts: Prompts = new Prompts(
     getInput('summarize'),
-    getInput('summarize_release_notes')
+    getInput('summarize_release_notes'),
+    getBooleanInput('poem_enabled'),
+    getInput('poem')
   )
 
   // Create two bots, one for summary and one for review

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -3,6 +3,8 @@ import {type Inputs} from './inputs'
 export class Prompts {
   summarize: string
   summarizeReleaseNotes: string
+  poemEnabled: boolean
+  poem: string
 
   summarizeFileDiff = `## GitHub PR Title
 
@@ -259,9 +261,16 @@ $comment
 \`\`\`
 `
 
-  constructor(summarize = '', summarizeReleaseNotes = '') {
+  constructor(
+    summarize = '',
+    summarizeReleaseNotes = '',
+    poemEnabled = false,
+    poem = ''
+  ) {
     this.summarize = summarize
     this.summarizeReleaseNotes = summarizeReleaseNotes
+    this.poemEnabled = poemEnabled
+    this.poem = poem
   }
 
   renderSummarizeFileDiff(
@@ -284,7 +293,10 @@ $comment
   }
 
   renderSummarize(inputs: Inputs): string {
-    const prompt = this.summarizePrefix + this.summarize
+    let prompt = this.summarizePrefix + this.summarize
+    if (this.poemEnabled) {
+      prompt += this.poem
+    }
     return inputs.render(prompt)
   }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by RedRover -->
### Summary by RedRover

- New Feature: Introduced a new "poem" feature in the code review process. Users can now enable or disable the generation of a poem at the end of the full summary by using the `poem_enabled` input. The `poem` input allows users to provide a prompt for generating the poem.
- Chore: Updated the workflow configuration in .github/workflows/redrover_review.yml to support the new "poem" feature and adjusted verbosity settings.
<!-- end of auto-generated comment: release notes by RedRover -->