### PR TITLE
poem formatting fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -242,7 +242,8 @@ inputs:
       **Poem**: Below the changes, include a whimsical, short poem written by 
       a dog to celebrate the changes. Format the poem as a quote using 
       the ">" symbol and feel free to use emojis where relevant. Do not add
-      extra lines breaks or <br> tags at the end of each poem line.
+      extra lines breaks or <br> tags at the end of each poem line. Also do
+      not extra lines between the lines of the poem.
   language:
     required: false
     description: ISO code for the response language

--- a/action.yml
+++ b/action.yml
@@ -242,8 +242,8 @@ inputs:
       **Poem**: Below the changes, include a whimsical, short poem written by 
       a dog to celebrate the changes. Format the poem as a quote using 
       the ">" symbol and feel free to use emojis where relevant. Do not add
-      extra lines breaks or <br> tags at the end of each poem line. Also do
-      not extra lines between the lines of the poem.
+      extra lines breaks or <br> tags at the end of each poem line. Also there 
+      should be no empty lines in the poem.
   language:
     required: false
     description: ISO code for the response language


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by RedRover -->
### Summary by RedRover

- Bug Fix: Improved the formatting of poems in `action.yml`. The update removes extra line breaks and `<br>` tags at the end of each poem line, and eliminates empty lines within poems. This change enhances readability and provides a cleaner presentation of the poems.
<!-- end of auto-generated comment: release notes by RedRover -->