### PR TITLE
Revert "poem formatting fix"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -242,8 +242,7 @@ inputs:
       **Poem**: Below the changes, include a whimsical, short poem written by 
       a dog to celebrate the changes. Format the poem as a quote using 
       the ">" symbol and feel free to use emojis where relevant. Do not add
-      extra lines breaks or <br> tags at the end of each poem line. Also there 
-      should be no empty lines in the poem.
+      extra lines breaks or <br> tags at the end of each poem line.
   language:
     required: false
     description: ISO code for the response language


### PR DESCRIPTION
Reverts bankrate/red-rover#25
<!-- This is an auto-generated comment: release notes by RedRover -->
### Summary by RedRover

- Revert: Removed the instruction to avoid empty lines in poem formatting. This change does not affect the functionality or behavior of the code, maintaining the same user experience as before.
<!-- end of auto-generated comment: release notes by RedRover -->