### PR TITLE
chore: update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/redrover_generate_standards.yml
+++ b/.github/workflows/redrover_generate_standards.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.x'
 
       - name: Cache Python dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('red_rover/requirements.txt') }}


### PR DESCRIPTION
update-github-actions-dependencies
<!-- This is an auto-generated comment: release notes by RedRover -->
### Summary by RedRover

- Chore: Updated the `actions/cache` GitHub Action from `v2` to `v3` in our workflow file `.github/workflows/redrover_generate_standards.yml`. This change enhances the efficiency of caching Python dependencies, potentially improving the speed and reliability of our CI/CD processes.
<!-- end of auto-generated comment: release notes by RedRover -->